### PR TITLE
Typos in Numbers + temp fix for InsertSeparators()

### DIFF
--- a/_mscorlib/System/Number.cs
+++ b/_mscorlib/System/Number.cs
@@ -389,8 +389,8 @@ namespace System
                     break;
                 
                 case 'N':
-                    // InsertGroupSeperators, AppendTrailingZeros, ReplaceNegativeSign
-                    result = InsertGroupSeperators(result, info);
+                    // InsertGroupSeparators, AppendTrailingZeros, ReplaceNegativeSign
+                    result = InsertGroupSeparators(result, info);
                     goto case 'F'; // falls through
                 case 'F':
                     // AppendTrailingZeros, ReplaceNegativeSign
@@ -410,7 +410,7 @@ namespace System
 
             if (format == 'N')
             {
-                result = InsertGroupSeperators(result, info);
+                result = InsertGroupSeparators(result, info);
             }
 
             result = ReplaceDecimalSeperator(result, info);
@@ -457,8 +457,11 @@ namespace System
             }
         }
 
-        private static String InsertGroupSeperators(String original, NumberFormatInfo info)
+        private static String InsertGroupSeparators(String original, NumberFormatInfo info)
         {
+			// Temporary fix for https://github.com/NETMF/netmf-interpreter/issues/366
+			if (original.Length == 0) return original;
+			
             int digitsStartPos = (original[0] == '-') ? 1 : 0;
 
             int decimalPointPos = original.IndexOf('.');

--- a/_mscorlib/System/Number.cs
+++ b/_mscorlib/System/Number.cs
@@ -286,6 +286,8 @@ namespace System
             ValidateFormat(format, out formatCh, out precision);
 
             String result = FormatNative(value, formatCh, precision);
+			// TODO: fix the FormatNative() method then remove the following line. See https://github.com/nanoframework/nf-interpreter/issues/285
+			if (result.Length == 0) return string.Empty;
 
             if (isInteger)
             {
@@ -459,9 +461,6 @@ namespace System
 
         private static String InsertGroupSeparators(String original, NumberFormatInfo info)
         {
-			// Temporary fix for https://github.com/NETMF/netmf-interpreter/issues/366
-			if (original.Length == 0) return original;
-			
             int digitsStartPos = (original[0] == '-') ? 1 : 0;
 
             int decimalPointPos = original.IndexOf('.');


### PR DESCRIPTION
The original name was InsertSeperators. Renamed to InsertSeparators.

Also added a temporary fix for the https://github.com/NETMF/netmf-interpreter/issues/366 NETMF issue that we will perhaps have to fix in the native code.

Signed-off-by: Christophe Gerbier <christophe@mikrobusnet.org>