### PR TITLE
Add missing load hints for Core Library targets

### DIFF
--- a/CoreLibrary/Nuget.CoreLibrary/build/nanoFramework.Assemblies.mscorlib.targets
+++ b/CoreLibrary/Nuget.CoreLibrary/build/nanoFramework.Assemblies.mscorlib.targets
@@ -14,5 +14,15 @@
     <Delete Condition="Exists('$(ProjectDir)$(OutDir)mscorlib.pe')" Files="$(ProjectDir)$(OutDir)mscorlib.pe" />
     <Delete Condition="Exists('$(ProjectDir)$(OutDir)mscorlib.pdbx')" Files="$(ProjectDir)$(OutDir)mscorlib.pdbx" />
   </Target>
+
+  <ItemGroup >
+    <NFMDP_PE_LoadHints Include="$(MSBuildThisFileDirectory)mscorlib.dll">
+      <InProject>false</InProject>
+    </NFMDP_PE_LoadHints>
   
+    <!--<NFMDP_STUB_Load Include="$(MSBuildThisFileDirectory)mscorlib.dll">
+      <InProject>false</InProject>
+    </NFMDP_STUB_Load>-->
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- this one was missing in order to load mscorlib as hint when calling MDP for core libraries compilation

Signed-off-by: José Simões <jose.simoes@eclo.solutions>