### PR TITLE
Changes in Base64 conversion

### DIFF
--- a/CoreLibrary/CoreLibrary.csproj
+++ b/CoreLibrary/CoreLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.props" Condition="Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.props')" />
+  <Import Project="packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props" Condition="Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props')" />
   <PropertyGroup>
     <NF_IsCoreLibrary>True</NF_IsCoreLibrary>
   </PropertyGroup>
@@ -55,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\mscorlib.xml</DocumentationFile>
     <NoWarn>,0169,0649,0659,0660,0661,3001,1591</NoWarn>
+    <LangVersion>3</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -78,7 +79,7 @@
     <NFMDP_STUB_GenerateSkeletonProject>CorLib</NFMDP_STUB_GenerateSkeletonProject>
     <!-- this is one is absolutly mandatory for the base class library -->
     <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>
-    <NFMDP_CMD_LINE_OUTPUT>false</NFMDP_CMD_LINE_OUTPUT>
+    <NFMDP_CMD_LINE_OUTPUT>true</NFMDP_CMD_LINE_OUTPUT>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\BitConverter.cs" />
@@ -435,9 +436,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\NuProj.Common.0.11.14-beta\build\dotnet\NuProj.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\NuProj.Common.0.11.14-beta\build\dotnet\NuProj.Common.targets'))" />
-    <Error Condition="!Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.props'))" />
-    <Error Condition="!Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.targets'))" />
+    <Error Condition="!Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props'))" />
+    <Error Condition="!Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets'))" />
   </Target>
   <Import Project="packages\NuProj.Common.0.11.14-beta\build\dotnet\NuProj.Common.targets" Condition="Exists('packages\NuProj.Common.0.11.14-beta\build\dotnet\NuProj.Common.targets')" />
-  <Import Project="packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.targets" Condition="Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037\build\nanoFramework.Tools.MSBuildSystem.targets')" />
+  <Import Project="packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets" Condition="Exists('packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets')" />
 </Project>

--- a/CoreLibrary/Nuget.CoreLibrary.DELIVERABLES/nanoFramework.CoreLibrary.DELIVERABLES.nuproj
+++ b/CoreLibrary/Nuget.CoreLibrary.DELIVERABLES/nanoFramework.CoreLibrary.DELIVERABLES.nuproj
@@ -28,7 +28,7 @@
     </Content>
     <Content Include="..\bin\$(Configuration)\mscorlib.xml">
       <Link>content\mscorlib.xml</Link>
-    </Content>    
+    </Content>
     <Content Include="..\obj\Release\Stubs\*.*">
       <Link>content\Stubs\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
@@ -57,7 +57,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.CoreLibrary.DELIVERABLES</Id>
-    <Version>1.0.0-preview014</Version>
+    <Version>1.0.0-preview015</Version>
     <Title>nanoFramework.CoreLibrary.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/CoreLibrary/Nuget.CoreLibrary/nanoFramework.CoreLibrary.nuproj
+++ b/CoreLibrary/Nuget.CoreLibrary/nanoFramework.CoreLibrary.nuproj
@@ -37,7 +37,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.CoreLibrary</Id>
-    <Version>1.0.0-preview014</Version>
+    <Version>1.0.0-preview015</Version>
     <Title>nanoFramework.CoreLibrary</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/CoreLibrary/System/Convert.cs
+++ b/CoreLibrary/System/Convert.cs
@@ -5,9 +5,17 @@
 //
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
+    [Flags]
+    public enum Base64FormattingOptions
+    {
+        None = 0,
+        InsertLineBreaks = 1
+    }
+
     //We don't want to implement this whole class, but VB needs an external function to convert any integer type to a Char.
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public static class Convert
@@ -494,157 +502,80 @@ namespace System
         }
 
         /// <summary>
-        /// Conversion array from 6 bit of value into base64 encoded character.
-        /// </summary>
-        static char[] s_rgchBase64EncodingDefault = new char[]
-        {
-           'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', /* 12 */
-           'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', /* 24 */
-           'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', /* 36 */
-           'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', /* 48 */
-           'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', /* 60 */
-           '8', '9', '!', '*'            /* 64 */
-        };
-
-        static char[] s_rgchBase64EncodingRFC4648 = new char[]
-        {
-            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', /* 12 */
-            'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', /* 24 */
-            'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', /* 36 */
-            'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', /* 48 */
-            'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', /* 60 */
-            '8', '9', '+', '/'            /* 64 */
-        };
-
-        static char[] s_rgchBase64Encoding = s_rgchBase64EncodingDefault;
-
-        static byte[] s_rgbBase64Decode = new byte[]
-        {
-          // Note we also accept ! and + interchangably.
-          // Note we also accept * and / interchangably.
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /*   0 -   7 */
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /*   8 -  15 */
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /*  16 -  23 */
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /*  24 -  31 */
-            0x00, 0x3E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /*  32 -  39 */
-            0x00, 0x00, 0x3f, 0x3e, 0x00, 0x00, 0x00, 0x3f, /*  40 -  47 */
-            0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, /*  48 -  55 */
-            0x3c, 0x3d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /*  56 -  63 */
-            0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, /*  64 -  71 */
-            0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, /*  72 -  79 */
-            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, /*  80 -  87 */
-            0x17, 0x18, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00, /*  88 -  95 */
-            0x00, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, /*  96 - 103 */
-            0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, /* 104 - 111 */
-            0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, /* 112 - 119 */
-            0x31, 0x32, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00  /* 120 - 127 */
-        };
-
-        private const int CCH_B64_IN_QUARTET = 4;
-        private const int CB_B64_OUT_TRIO = 3;
-
-        static private int GetBase64EncodedLength(int binaryLen)
-        {
-            return (((binaryLen / 3) + (((binaryLen % 3) != 0) ? 1 : 0)) * 4);
-
-        }
-
-        public static bool UseRFC4648Encoding
-        {
-            get { return s_rgchBase64Encoding == s_rgchBase64EncodingRFC4648; }
-            set { s_rgchBase64Encoding = (value ? s_rgchBase64EncodingRFC4648 : s_rgchBase64EncodingDefault); }
-        }
-
-        /// <summary>
         /// Converts an array of 8-bit unsigned integers to its equivalent String representation encoded with base 64 digits.
         /// </summary>
         /// <param name="inArray">An array of 8-bit unsigned integers. </param>
-        /// <returns>The String representation, in base 64, of the contents of inArray.</returns>
+        /// <returns>The String representation, in base 64, of the contents of <paramref name="inArray"/>.</returns>
         public static string ToBase64String(byte[] inArray)
-        {
-            return ToBase64String(inArray, 0, inArray.Length);
-        }
-
-        public static string ToBase64String(byte[] inArray, int offset, int length)
         {
             if (inArray == null)
             {
                 throw new ArgumentNullException();
             }
-
-            if (length == 0) return "";
-
-            if (offset + length > inArray.Length) throw new ArgumentOutOfRangeException();
-
-            // Create array of characters with appropriate length.
-            int inArrayLen = length;
-            int outArrayLen = GetBase64EncodedLength(inArrayLen);
-            char[] outArray = new char[outArrayLen];
-
-            // encoding starts from end of string
-
-
-            //
-            // Convert the input buffer bytes through the encoding table and
-            // out into the output buffer.
-            //
-            int iInputEnd = offset + (outArrayLen / CCH_B64_IN_QUARTET - 1) * CB_B64_OUT_TRIO;
-            int iInput = offset, iOutput = 0;
-            byte uc0 = 0, uc1 = 0, uc2 = 0;
-            // Loop is for all trios except of last one.
-            for (; iInput < iInputEnd; iInput += CB_B64_OUT_TRIO, iOutput += CCH_B64_IN_QUARTET)
-            {
-                uc0 = inArray[iInput];
-                uc1 = inArray[iInput + 1];
-                uc2 = inArray[iInput + 2];
-                // Writes data to output character array.
-                outArray[iOutput] = s_rgchBase64Encoding[uc0 >> 2];
-                outArray[iOutput + 1] = s_rgchBase64Encoding[((uc0 << 4) & 0x30) | ((uc1 >> 4) & 0xf)];
-                outArray[iOutput + 2] = s_rgchBase64Encoding[((uc1 << 2) & 0x3c) | ((uc2 >> 6) & 0x3)];
-                outArray[iOutput + 3] = s_rgchBase64Encoding[uc2 & 0x3f];
-            }
-
-            // Now we process the last trio of bytes. This trio might be incomplete and thus require special handling.
-            // This code could be incorporated into main "for" loop, but hte code would be slower becuase of extra 2 "if"
-            uc0 = inArray[iInput];
-            uc1 = ((iInput + 1) < (offset + inArrayLen)) ? inArray[iInput + 1] : (byte)0;
-            uc2 = ((iInput + 2) < (offset + inArrayLen)) ? inArray[iInput + 2] : (byte)0;
-            // Writes data to output character array.
-            outArray[iOutput] = s_rgchBase64Encoding[uc0 >> 2];
-            outArray[iOutput + 1] = s_rgchBase64Encoding[((uc0 << 4) & 0x30) | ((uc1 >> 4) & 0xf)];
-            outArray[iOutput + 2] = s_rgchBase64Encoding[((uc1 << 2) & 0x3c) | ((uc2 >> 6) & 0x3)];
-            outArray[iOutput + 3] = s_rgchBase64Encoding[uc2 & 0x3f];
-
-            switch (inArrayLen % CB_B64_OUT_TRIO)
-            {
-                //
-                // One byte out of three, add padding and fall through
-                //
-                case 1:
-                    outArray[outArrayLen - 2] = '=';
-                    goto case 2;
-                //
-                // Two bytes out of three, add padding.
-                //
-                case 2:
-                    outArray[outArrayLen - 1] = '=';
-                    break;
-            }
-
-            // Creates string out of character array and return it.
-            return new string(outArray);
+            return ToBase64String(inArray, 0, inArray.Length, Base64FormattingOptions.None);
         }
 
         /// <summary>
-        /// Converts the specified String, which encodes binary data as base 64 digits, to an equivalent 8-bit unsigned integer array.
+        /// Converts an array of 8-bit unsigned integers to its equivalent string representation that is encoded with base-64 digits. A parameter specifies whether to insert line breaks in the return value.
         /// </summary>
-        /// <param name="inString">Base64 encoded string to convert</param>
-        /// <returns>An array of 8-bit unsigned integers equivalent to s.</returns>
-        /// <remarks>s is composed of base 64 digits, white space characters, and trailing padding characters.
-        /// The base 64 digits in ascending order from zero are the uppercase characters 'A' to 'Z',
-        /// lowercase characters 'a' to 'z', numerals '0' to '9', and the symbols '+' and '/'.
-        /// An arbitrary number of white space characters can appear in s because all white space characters are ignored.
-        /// The valueless character, '=', is used for trailing padding. The end of s can consist of zero, one, or two padding characters.
+        /// <param name="inArray">An array of 8-bit unsigned integers.</param>
+        /// <param name="options">cref="System.InsertLineBreaks" to insert a line break every 76 characters, or None to not insert line breaks.</param>
+        /// <returns>The string representation in base 64 of the elements in <paramref name="inArray"/>.</returns>
+        public static String ToBase64String(byte[] inArray, Base64FormattingOptions options)
+        {
+            if (inArray == null)
+            {
+                throw new ArgumentNullException();
+            }
+            return ToBase64String(inArray, 0, inArray.Length, options);
+        }
+
+        /// <summary>
+        /// Converts a subset of an array of 8-bit unsigned integers to its equivalent string representation that is encoded with base-64 digits. Parameters specify the subset as an offset in the input array, and the number of elements in the array to convert.
+        /// </summary>
+        /// <param name="inArray">An array of 8-bit unsigned integers. </param>
+        /// <param name="offset">An offset in <paramref name="inArray"/>.</param>
+        /// <param name="length">The number of elements of <paramref name="inArray"/> to convert.</param>
+        /// <returns>The string representation in base 64 of <paramref name="length"/> elements of <paramref name="inArray"/>, starting at position <paramref name="offset"/>.</returns>
+        public static String ToBase64String(byte[] inArray, int offset, int length)
+        {
+            return ToBase64String(inArray, offset, length, Base64FormattingOptions.None);
+        }
+
+        /// <summary>
+        /// Converts a subset of an array of 8-bit unsigned integers to its equivalent string representation that is encoded with base-64 digits. Parameters specify the subset as an offset in the input array, the number of elements in the array to convert, and whether to insert line breaks in the return value.
+        /// </summary>
+        /// <param name="inArray">An array of 8-bit unsigned integers. </param>
+        /// <param name="offset">An offset in <paramref name="inArray"/>.</param>
+        /// <param name="length">The number of elements of <paramref name="inArray"/> to convert.</param>
+        /// <param name="options">cref="System.InsertLineBreaks" to insert a line break every 76 characters, or None to not insert line breaks.</param>
+        /// <returns>The string representation in base 64 of <paramref name="length"/> elements of <paramref name="inArray"/>, starting at position <paramref name="offset"/>.</returns>
+        public static string ToBase64String(byte[] inArray, int offset, int length, Base64FormattingOptions options)
+        {
+            //Do data verfication
+            if (inArray == null)
+                throw new ArgumentNullException();
+            if (length < 0)
+                throw new ArgumentOutOfRangeException();
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException();
+            if (options < Base64FormattingOptions.None || options > Base64FormattingOptions.InsertLineBreaks)
+                throw new ArgumentException();
+
+            return ToBase64String(inArray, offset, length, options == Base64FormattingOptions.InsertLineBreaks ? true : false);
+        }
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private static extern string ToBase64String(byte[] inArray, int offset, int length, bool insertLineBreaks);
+
+        /// <summary>
+        /// Converts the specified string, which encodes binary data as base-64 digits, to an equivalent 8-bit unsigned integer array.
+        /// </summary>
+        /// <param name="inString">The string to convert.</param>
+        /// <returns>An array of 8-bit unsigned integers that is equivalent to <paramref name="inString"/></returns>
+        /// <remarks>s is composed of base-64 digits, white-space characters, and trailing padding characters. The base-64 digits in ascending order from zero are the uppercase characters "A" to "Z", lowercase characters "a" to "z", numerals "0" to "9", and the symbols "+" and "/".
+        /// The white-space characters, and their Unicode names and hexadecimal code points, are tab(CHARACTER TABULATION, U+0009), newline(LINE FEED, U+000A), carriage return (CARRIAGE RETURN, U+000D), and blank(SPACE, U+0020). An arbitrary number of white-space characters can appear in s because all white-space characters are ignored.
+        /// The valueless character, "=", is used for trailing padding. The end of s can consist of zero, one, or two padding characters.
         /// </remarks>
         public static byte[] FromBase64String(string inString)
         {
@@ -658,74 +589,36 @@ namespace System
             return FromBase64CharArray(chArray, 0, chArray.Length);
         }
 
-        public static byte[] FromBase64CharArray(char[] inString, int offset, int length)
+        /// <summary>
+        /// Converts a subset of a Unicode character array, which encodes binary data as base-64 digits, to an equivalent 8-bit unsigned integer array. Parameters specify the subset in the input array and the number of elements to convert.
+        /// </summary>
+        /// <param name="inArray">A Unicode character array.</param>
+        /// <param name="offset">A position within <paramref name="inArray"/>.</param>
+        /// <param name="length">The number of elements in <paramref name="inArray"/> to convert. </param>
+        /// <returns>An array of 8-bit unsigned integers equivalent to <paramref name="length"/> elements at position <paramref name="offset"/> in <paramref name="inArray"/>.</returns>
+        public static byte[] FromBase64CharArray(char[] inArray, int offset, int length)
         {
-            if (length == 0) return new byte[0];
 
-            // Checks that length of string is multiple of 4
-            int inLength = length;
-            if (inLength % CCH_B64_IN_QUARTET != 0)
-            {
-                throw new ArgumentException("Encoded string length should be multiple of 4");
-            }
+            if (inArray == null)
+                throw new ArgumentNullException();
 
-            // Maximum buffer size needed.
-            int outCurPos = (((inLength + (CCH_B64_IN_QUARTET - 1)) / CCH_B64_IN_QUARTET) * CB_B64_OUT_TRIO);
-            if (inString[offset + inLength - 1] == '=')
-            {   // If the last was "=" - it means last byte was padded/
-                --outCurPos;
-                // If one more '=' - two bytes were actually padded.
-                if (inString[offset + inLength - 2] == '=')
-                {
-                    --outCurPos;
-                }
-            }
+            if (length < 0)
+                throw new ArgumentOutOfRangeException();
 
-            // Output array.
-            byte[] retArray = new byte[outCurPos];
-            // Array of 4 bytes - temporary.
-            byte[] rgbOutput = new byte[CCH_B64_IN_QUARTET];
-            // Loops over each 4 bytes quartet.
-            for (int inCurPos = offset + inLength;
-                 inCurPos > offset;
-                 inCurPos -= CCH_B64_IN_QUARTET)
-            {
-                int ibDest = 0;
-                for (; ibDest < CB_B64_OUT_TRIO + 1; ibDest++)
-                {
-                    int ichGet = inCurPos + ibDest - CCH_B64_IN_QUARTET;
-                    // Equal sign can be only at the end and maximum of 2
-                    if (inString[ichGet] == '=')
-                    {
-                        if (ibDest < 2 || inCurPos != (offset + inLength))
-                        {
-                            throw new ArgumentException("Invalid base64 encoded string");
-                        }
-                        break;
-                    }
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException();
 
-                    // Applies decoding table to the character.
-                    rgbOutput[ibDest] = s_rgbBase64Decode[inString[ichGet]];
-                }
+            if (offset > inArray.Length - length)
+                throw new ArgumentOutOfRangeException();
 
-                // Convert 4 bytes in rgbOutput, each having 6 bits into three bytes in final data.
-                switch (ibDest)
-                {
-                    default:
-                        retArray[--outCurPos] = (byte)(((rgbOutput[2] & 0x03) << 6) | rgbOutput[3]);
-                        goto case 3;
+            // copy to new array
+            char[] destinationArray = new char[length];
+            Array.Copy(inArray, offset, destinationArray, 0, length);
 
-                    case 3:
-                        retArray[--outCurPos] = (byte)(((rgbOutput[1] & 0x0F) << 4) | (((rgbOutput[2]) & 0x3C) >> 2));
-                        goto case 2;
-
-                    case 2:
-                        retArray[--outCurPos] = (byte)(((rgbOutput[0]) << 2) | (((rgbOutput[1]) & 0x30) >> 4));
-                        break;
-                }
-            }
-
-            return retArray;
+            return FromBase64CharArray(inArray, length);
         }
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private static extern byte[] FromBase64CharArray(char[] inArray, int length);
     }
 }

--- a/CoreLibrary/packages.config
+++ b/CoreLibrary/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0037" targetFramework="net46" />
+  <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0039" targetFramework="net46" />
   <package id="NuProj" version="0.11.14-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.11.14-beta" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- remove old code
- replace with all methods from standard API
- add Base64FormattingOptions enum
- add methods for native call
- fixes #33
- fixes #34 (still missing the code at the native end)
- updates MSBuild System Nuget
- bumped Nuget version to preview015

Signed-off-by: José Simões <jose.simoes@eclo.solutions>