### PR TITLE
Work on DateTime managed code

### DIFF
--- a/CoreLibrary/CoreLibrary.csproj
+++ b/CoreLibrary/CoreLibrary.csproj
@@ -161,7 +161,6 @@
     <Compile Include="System\Text\UTF8Encoding.cs" />
     <Compile Include="System\ThreadAttributes.cs" />
     <Compile Include="System\TimeSpan.cs" />
-    <Compile Include="System\TimeZone.cs" />
     <Compile Include="System\Type.cs" />
     <Compile Include="System\TypeCode.cs" />
     <Compile Include="System\TypedReference.cs" />

--- a/CoreLibrary/System/Array.cs
+++ b/CoreLibrary/System/Array.cs
@@ -24,7 +24,7 @@ namespace System
         /// <remarks><para>Unlike most classes, Array provides the CreateInstance method, instead of public constructors, to allow for late bound access.</para>
         /// <para>Reference-type elements are initialized to nullNothingnullptrunit a null reference(Nothing in Visual Basic). Value-type elements are initialized to zero.</para>
         /// <para>This method is an O(n) operation, where n is length.</para></remarks>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern Array CreateInstance(Type elementType, int length);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace System
         /// <param name="destinationArray">The Array that receives the data.</param>
         /// <param name="destinationIndex">A 32-bit integer that represents the index in the destinationArray at which storing begins.</param>
         /// <param name="length">A 32-bit integer that represents the number of elements to copy.</param>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void Copy(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length);
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System
         /// <param name="array">The Array whose elements need to be cleared.</param>
         /// <param name="index">The starting index of the range of elements to clear.</param>
         /// <param name="length">The number of elements to clear.</param>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void Clear(Array array, int index, int length);
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace System
         /// </value>
         public extern int Length
         {
-            [MethodImplAttribute(MethodImplOptions.InternalCall)]
+            [MethodImpl(MethodImplOptions.InternalCall)]
             get;
         }
 
@@ -134,10 +134,10 @@ namespace System
 
         extern Object IList.this[int index]
         {
-            [MethodImplAttribute(MethodImplOptions.InternalCall)]
+            [MethodImpl(MethodImplOptions.InternalCall)]
             get;
 
-            [MethodImplAttribute(MethodImplOptions.InternalCall)]
+            [MethodImpl(MethodImplOptions.InternalCall)]
             set;
         }
 
@@ -323,7 +323,7 @@ namespace System
             return -1;
         }
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern bool TrySzIndexOf(Array sourceArray, int sourceIndex, int count, Object value, out int retVal);
 
       // This is the underlying Enumerator for all of our array-based data structures (Array, ArrayList, Stack, and Queue)

--- a/CoreLibrary/System/TimeSpan.cs
+++ b/CoreLibrary/System/TimeSpan.cs
@@ -65,7 +65,7 @@ namespace System
         /// <param name="hours">Number of hours.</param>
         /// <param name="minutes">Number of minutes.</param>
         /// <param name="seconds">Number of seconds.</param>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public extern TimeSpan(int hours, int minutes, int seconds);
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace System
         /// <param name="hours">Number of hours.</param>
         /// <param name="minutes">Number of minutes.</param>
         /// <param name="seconds">Number of seconds.</param>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public extern TimeSpan(int days, int hours, int minutes, int seconds);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace System
         /// <param name="minutes">Number of minutes.</param>
         /// <param name="seconds">Number of seconds.</param>
         /// <param name="milliseconds">Number of milliseconds.</param>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public extern TimeSpan(int days, int hours, int minutes, int seconds, int milliseconds);
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace System
         {
             get
             {
-                return (int)((NumberOfTicks / TicksPerHour) % 24);
+                return (int)(NumberOfTicks / TicksPerHour % 24);
             }
         }
 
@@ -133,7 +133,7 @@ namespace System
         {
             get
             {
-                return (int)((NumberOfTicks / TicksPerMillisecond) % 1000);
+                return (int)(NumberOfTicks / TicksPerMillisecond % 1000);
             }
         }
 
@@ -145,7 +145,7 @@ namespace System
         {
             get
             {
-                return (int)((NumberOfTicks / TicksPerMinute) % 60);
+                return (int)(NumberOfTicks / TicksPerMinute % 60);
             }
         }
 
@@ -157,7 +157,7 @@ namespace System
         {
             get
             {
-                return (int)((NumberOfTicks / TicksPerSecond) % 60);
+                return (int)(NumberOfTicks / TicksPerSecond % 60);
             }
         }
 
@@ -181,7 +181,7 @@ namespace System
         /// <para>0 if t1 is equal to t2.</para>
         /// <para>1 if t1 is longer than t2.</para>
         /// </returns>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern int Compare(TimeSpan t1, TimeSpan t2);
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace System
         /// <para>0 if This instance is equal to value.</para>
         /// <para>1 if This instance is longer than value or value is null.</para>
         /// </returns>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public extern int CompareTo(Object value);
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace System
         /// </summary>
         /// <param name="value">An object to compare with this instance.</param>
         /// <returns>true if value is a TimeSpan object that represents the same time interval as the current TimeSpan structure; otherwise, false.</returns>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public override extern bool Equals(Object value);
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace System
         /// <param name="t1">The first time interval to compare.</param>
         /// <param name="t2">The second time interval to compare.</param>
         /// <returns>true if the values of t1 and t2 are equal; otherwise, false.</returns>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool Equals(TimeSpan t1, TimeSpan t2);
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace System
         /// </summary>
         /// <returns>The string representation of the current TimeSpan value.</returns>
         /// <remarks>The returned string is formatted with the "c" format specifier and has the following format: [-][d.]hh:mm:ss[.fffffff]</remarks>
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public override extern String ToString();
 
         /// <summary>


### PR DESCRIPTION
This fixes issue #50.
Some methods have been moved to native side for better efficiency.

Also, the TimeZone class have been dropped since nanoFramework is only using UTC time by default. See : https://github.com/nanoframework/nf-interpreter/issues/335

Signed-off-by: Christophe Gerbier <christophe@mikrobusnet.org>