### PR TITLE
Fix CoreLib project

### DIFF
--- a/CoreLibrary/CoreLibrary.nfproj
+++ b/CoreLibrary/CoreLibrary.nfproj
@@ -24,6 +24,15 @@
     <DocumentationFile>bin\$(Configuration)\mscorlib.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>  
+  <PropertyGroup>
     <!-- generate PE: TRUE -->
     <NFMDP_PE_SKIP>false</NFMDP_PE_SKIP>
     <NFMDP_PE_NoBitmapCompression>true</NFMDP_PE_NoBitmapCompression>
@@ -208,7 +217,181 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <NFMDP_PE_ExcludeClassByName Include="System.AttributeTargets">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.AttributeUsageAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.ComponentModel.EditorBrowsableAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.CLSCompliantAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.DBNull">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Decimal">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.ConditionalAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggableAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <!--<NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerBrowsableAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>-->
+    <!--<NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerBrowsableState">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>-->
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerDisplayAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerHiddenAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerNonUserCodeAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerStepperBoundaryAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerStepThroughAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerTypeProxyAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.FlagsAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.MTAThreadAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.NonSerializedAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.ObsoleteAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.ParamArrayAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyCompanyAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyConfigurationAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyCopyrightAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyCultureAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyDefaultAliasAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyDelaySignAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyDescriptionAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyFileVersionAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyFlagsAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyInformationalVersionAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyKeyFileAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyKeyNameAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyProductAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyTitleAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyTrademarkAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.AssemblyVersionAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.DefaultMemberAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.FieldNoReflectionAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Reflection.MethodImplAttributes">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.CompilerServices.IndexerNameAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.CompilerServices.MethodCodeType">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.CompilerServices.MethodImplAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.CompilerServices.MethodImplOptions">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.InteropServices.CharSet">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.InteropServices.ComVisibleAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.InteropServices.GuidAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.InteropServices.LayoutKind">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.InteropServices.OutAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.InteropServices.StructLayoutAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Runtime.Remoting.Proxies.__TransparentProxy">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.SerializableAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.STAThreadAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Threading.Timeout">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.TypedReference">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.UIntPtr">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+  </ItemGroup>
+  <ItemGroup>
+   <None Include="key.snk" />
+   <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/CoreLibrary/Nuget.CoreLibrary.DELIVERABLES/nanoFramework.CoreLibrary.DELIVERABLES.nuproj
+++ b/CoreLibrary/Nuget.CoreLibrary.DELIVERABLES/nanoFramework.CoreLibrary.DELIVERABLES.nuproj
@@ -57,7 +57,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.CoreLibrary.DELIVERABLES</Id>
-    <Version>1.0.0-preview021</Version>
+    <Version>1.0.0-preview022</Version>
     <Title>nanoFramework.CoreLibrary.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/CoreLibrary/Nuget.CoreLibrary/nanoFramework.CoreLibrary.nuproj
+++ b/CoreLibrary/Nuget.CoreLibrary/nanoFramework.CoreLibrary.nuproj
@@ -39,7 +39,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.CoreLibrary</Id>
-    <Version>1.0.0-preview021</Version>
+    <Version>1.0.0-preview022</Version>
     <Title>nanoFramework.CoreLibrary</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/CoreLibrary/nanoFramework.CoreLibrary.sln
+++ b/CoreLibrary/nanoFramework.CoreLibrary.sln
@@ -6,14 +6,19 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "CoreLibrary", "CoreLibrary.nfproj", "{BE7B95D5-087C-45F8-8197-4B438BEDFE11}"
 EndProject
 Project("{5DD5E4FA-CB73-4610-85AB-557B54E96AA9}") = "nanoFramework.CoreLibrary", "Nuget.CoreLibrary\nanoFramework.CoreLibrary.nuproj", "{96EABA11-6A33-454D-A7B2-B96CA5617E8C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{BE7B95D5-087C-45F8-8197-4B438BEDFE11} = {BE7B95D5-087C-45F8-8197-4B438BEDFE11}
+	EndProjectSection
 EndProject
 Project("{5DD5E4FA-CB73-4610-85AB-557B54E96AA9}") = "nanoFramework.CoreLibrary.DELIVERABLES", "Nuget.CoreLibrary.DELIVERABLES\nanoFramework.CoreLibrary.DELIVERABLES.nuproj", "{8FD36AD6-387C-48F0-A695-52D9149216FB}"
+	ProjectSection(ProjectDependencies) = postProject
+		{BE7B95D5-087C-45F8-8197-4B438BEDFE11} = {BE7B95D5-087C-45F8-8197-4B438BEDFE11}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FB18B7BF-534A-4539-8D12-8379BED2A358}"
 	ProjectSection(SolutionItems) = preProject
 		packages.config = packages.config
 	EndProjectSection
-EndProject
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5228FA24-C912-44F0-96E4-F8CAB9307265}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5228FA24-C912-44F0-96E4-F8CAB9307265}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5228FA24-C912-44F0-96E4-F8CAB9307265}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{5228FA24-C912-44F0-96E4-F8CAB9307265}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Release|Any CPU.Build.0 = Release|Any CPU
 		{96EABA11-6A33-454D-A7B2-B96CA5617E8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{96EABA11-6A33-454D-A7B2-B96CA5617E8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96EABA11-6A33-454D-A7B2-B96CA5617E8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -33,10 +38,6 @@ Global
 		{8FD36AD6-387C-48F0-A695-52D9149216FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FD36AD6-387C-48F0-A695-52D9149216FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FD36AD6-387C-48F0-A695-52D9149216FB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BE7B95D5-087C-45F8-8197-4B438BEDFE11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- the PE class exclusions were accidentally dropped when moving to the new project type
- the assembly signing was also missed
- correct project build dependency (in solution)
- bump Nuget version to 1.0.0-preview022

Signed-off-by: José Simões <jose.simoes@eclo.solutions>