### PR TITLE
Improvements in all base classes

### DIFF
--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -14,22 +14,22 @@
     <Folder Include="content\" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\obj\Release\Stubs\*.*">
+    <Content Include="..\bin\$(Configuration)\Stubs\*.*">
       <Link>content\Stubs\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.txt">
+    <Content Include="..\bin\$(Configuration)\*.txt">
       <Link>content\txt\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.dump">
+    <Content Include="..\bin\$(Configuration)\*.dump">
       <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.strings">
+    <Content Include="..\bin\$(Configuration)\*.strings">
       <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.resources">
+    <Content Include="..\bin\$(Configuration)\*.resources">
       <Link>content\resources\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.il">
+    <Content Include="..\bin\$(Configuration)\*.il">
       <Link>content\disasm\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
   </ItemGroup>
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview007</Version>
+    <Version>1.0.0-preview008</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -11,16 +11,16 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\obj\Release\Windows.Devices.Gpio.dll">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Gpio.dll">
       <Link>lib\Windows.Devices.Gpio.dll</Link>
     </Content>
-    <Content Include="..\obj\Release\Windows.Devices.Gpio.pdb">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Gpio.pdb">
       <Link>lib\Windows.Devices.Gpio.pdb</Link>
     </Content>
-    <Content Include="..\obj\Release\Windows.Devices.Gpio.pdbx">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Gpio.pdbx">
       <Link>lib\Windows.Devices.Gpio.pdbx</Link>
     </Content>
-    <Content Include="..\obj\Release\Windows.Devices.Gpio.pe">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Gpio.pe">
       <Link>lib\Windows.Devices.Gpio.pe</Link>
     </Content>
     <Content Include="..\bin\$(Configuration)\Windows.Devices.Gpio.xml">
@@ -39,7 +39,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview007</Version>
+    <Version>1.0.0-preview008</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Windows.Devices.Gpio")]
 [assembly: AssemblyCompany("nanoFramework Contributors")]
 [assembly: AssemblyProduct("Windows.Devices.Gpio")]
-[assembly: AssemblyCopyright("Copyright © nanoFrameowrk Contributors 2017")]
+[assembly: AssemblyCopyright("Copyright © nanoFramework Contributors 2017")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
+++ b/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
@@ -34,12 +34,13 @@
     <NFMDP_PE_VerboseMinimize>true</NFMDP_PE_VerboseMinimize>
     <!-- generate STUBS: TRUE -->
     <NFMDP_STUB_SKIP>false</NFMDP_STUB_SKIP>
-    <!-- we like verbose -->
     <NFMDP_STUB_Verbose>true</NFMDP_STUB_Verbose>
+    <!-- this is one is absolutely mandatory for base class libraries -->
+    <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>    
     <NFMDP_STUB_VerboseMinimize>true</NFMDP_STUB_VerboseMinimize>
-    <NFMDP_STUB_GenerateSkeletonFile>Stubs\windows_devices_gpio_native</NFMDP_STUB_GenerateSkeletonFile>
-    <NFMDP_STUB_GenerateSkeletonProject>Windows_Devices_Gpio</NFMDP_STUB_GenerateSkeletonProject>
-    <NFMDP_CMD_LINE_OUTPUT>true</NFMDP_CMD_LINE_OUTPUT>
+    <NFMDP_STUB_GenerateSkeletonFile>Stubs\win_dev_gpio_native</NFMDP_STUB_GenerateSkeletonFile>
+    <NFMDP_STUB_GenerateSkeletonProject>Win_Dev_Gpio</NFMDP_STUB_GenerateSkeletonProject>
+    <NFMDP_CMD_LINE_OUTPUT>false</NFMDP_CMD_LINE_OUTPUT>
     <Name>Windows.Devices.Gpio</Name>
   </PropertyGroup>
   <ItemGroup>

--- a/Windows.Devices.Spi/AssemblyInfo.cs
+++ b/Windows.Devices.Spi/AssemblyInfo.cs
@@ -6,7 +6,7 @@
 [assembly: AssemblyTitle("Windows.Devices.Spi")]
 [assembly: AssemblyCompany("nanoFramework Contributors")]
 [assembly: AssemblyProduct("Windows.Devices.Spi")]
-[assembly: AssemblyCopyright("Copyright © nanoFrameowrk Contributors 2017")]
+[assembly: AssemblyCopyright("Copyright © nanoFramework Contributors 2017")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -14,22 +14,22 @@
     <Folder Include="content\" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\obj\Release\Stubs\*.*">
+    <Content Include="..\bin\$(Configuration)\Stubs\*.*">
       <Link>content\Stubs\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.txt">
+    <Content Include="..\bin\$(Configuration)\*.txt">
       <Link>content\txt\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.dump">
+    <Content Include="..\bin\$(Configuration)\*.dump">
       <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.strings">
+    <Content Include="..\bin\$(Configuration)\*.strings">
       <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.resources">
+    <Content Include="..\bin\$(Configuration)\*.resources">
       <Link>content\resources\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\Release\*.il">
+    <Content Include="..\bin\$(Configuration)\*.il">
       <Link>content\disasm\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
   </ItemGroup>
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview003</Version>
+    <Version>1.0.0-preview004</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -11,16 +11,16 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\obj\Release\Windows.Devices.Spi.dll">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Spi.dll">
       <Link>lib\Windows.Devices.Spi.dll</Link>
     </Content>
-    <Content Include="..\obj\Release\Windows.Devices.Spi.pdb">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Spi.pdb">
       <Link>lib\Windows.Devices.Spi.pdb</Link>
     </Content>
-    <Content Include="..\obj\Release\Windows.Devices.Spi.pdbx">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Spi.pdbx">
       <Link>lib\Windows.Devices.Spi.pdbx</Link>
     </Content>
-    <Content Include="..\obj\Release\Windows.Devices.Spi.pe">
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.Spi.pe">
       <Link>lib\Windows.Devices.Spi.pe</Link>
     </Content>
     <Content Include="..\bin\$(Configuration)\Windows.Devices.Spi.xml">
@@ -36,7 +36,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview003</Version>
+    <Version>1.0.0-preview004</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Windows.Devices.Spi.nfproj
+++ b/Windows.Devices.Spi/Windows.Devices.Spi.nfproj
@@ -37,11 +37,12 @@
     <NFMDP_PE_VerboseMinimize>true</NFMDP_PE_VerboseMinimize>
     <!-- generate STUBS: TRUE -->
     <NFMDP_STUB_SKIP>false</NFMDP_STUB_SKIP>
-    <!-- we like verbose -->
     <NFMDP_STUB_Verbose>true</NFMDP_STUB_Verbose>
+    <!-- this is one is absolutely mandatory for base class libraries -->
+    <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>    
     <NFMDP_STUB_VerboseMinimize>true</NFMDP_STUB_VerboseMinimize>
-    <NFMDP_STUB_GenerateSkeletonFile>Stubs\windows_devices_spi_native</NFMDP_STUB_GenerateSkeletonFile>
-    <NFMDP_STUB_GenerateSkeletonProject>Windows_Devices_Spi</NFMDP_STUB_GenerateSkeletonProject>
+    <NFMDP_STUB_GenerateSkeletonFile>Stubs\win_dev_spi_native</NFMDP_STUB_GenerateSkeletonFile>
+    <NFMDP_STUB_GenerateSkeletonProject>Win_Dev_Spi</NFMDP_STUB_GenerateSkeletonProject>
     <NFMDP_CMD_LINE_OUTPUT>false</NFMDP_CMD_LINE_OUTPUT>
   </PropertyGroup>
   <ItemGroup>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
@@ -14,22 +14,22 @@
     <Folder Include="content\" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\obj\$(Configuration)\Stubs\*.*">
+    <Content Include="..\bin\$(Configuration)\Stubs\*.*">
       <Link>content\Stubs\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\*.txt">
+    <Content Include="..\bin\$(Configuration)\*.txt">
       <Link>content\txt\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\*.dump">
+    <Content Include="..\bin\$(Configuration)\*.dump">
       <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\*.strings">
+    <Content Include="..\bin\$(Configuration)\*.strings">
       <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\*.resources">
+    <Content Include="..\bin\$(Configuration)\*.resources">
       <Link>content\resources\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\*.il">
+    <Content Include="..\bin\$(Configuration)\*.il">
       <Link>content\disasm\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
   </ItemGroup>
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.nanoFramework.Runtime.Events.DELIVERABLES</Id>
-    <Version>1.0.0-preview003</Version>
+    <Version>1.0.0-preview004</Version>
     <Title>nanoFramework.nanoFramework.Runtime.Events.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
@@ -11,16 +11,16 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\obj\$(Configuration)\nanoFramework.Runtime.Events.dll">
+    <Content Include="..\bin\$(Configuration)\nanoFramework.Runtime.Events.dll">
       <Link>lib\nanoFramework.Runtime.Events.dll</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\nanoFramework.Runtime.Events.pdb">
+    <Content Include="..\bin\$(Configuration)\nanoFramework.Runtime.Events.pdb">
       <Link>lib\nanoFramework.Runtime.Events.pdb</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\nanoFramework.Runtime.Events.pdbx">
+    <Content Include="..\bin\$(Configuration)\nanoFramework.Runtime.Events.pdbx">
       <Link>lib\nanoFramework.Runtime.Events.pdbx</Link>
     </Content>
-    <Content Include="..\obj\$(Configuration)\nanoFramework.Runtime.Events.pe">
+    <Content Include="..\bin\$(Configuration)\nanoFramework.Runtime.Events.pe">
       <Link>lib\nanoFramework.Runtime.Events.pe</Link>
     </Content>
     <Content Include="..\bin\$(Configuration)\nanoFramework.Runtime.Events.xml">
@@ -39,7 +39,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.nanoFramework.Runtime.Events</Id>
-    <Version>1.0.0-preview003</Version>
+    <Version>1.0.0-preview004</Version>
     <Title>nanoFramework.nanoFramework.Runtime.Events</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("nanoFramework.Runtime.Events")]
 [assembly: AssemblyCompany("nanoFramework Contributors")]
 [assembly: AssemblyProduct("nanoFramework.Runtime.Events")]
-[assembly: AssemblyCopyright("Copyright © nanoFrameowrk Contributors 2017")]
+[assembly: AssemblyCopyright("Copyright © nanoFramework Contributors 2017")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/nanoFramework.Runtime.Events/nanoFramework.Runtime.Events.nfproj
+++ b/nanoFramework.Runtime.Events/nanoFramework.Runtime.Events.nfproj
@@ -34,11 +34,12 @@
     <NFMDP_PE_VerboseMinimize>true</NFMDP_PE_VerboseMinimize>
     <!-- generate STUBS: TRUE -->
     <NFMDP_STUB_SKIP>false</NFMDP_STUB_SKIP>
-    <!-- we like verbose -->
     <NFMDP_STUB_Verbose>true</NFMDP_STUB_Verbose>
+    <!-- this is one is absolutely mandatory for base class libraries -->
+    <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>    
     <NFMDP_STUB_VerboseMinimize>true</NFMDP_STUB_VerboseMinimize>
-    <NFMDP_STUB_GenerateSkeletonFile>Stubs\nanoframework_runtime_events</NFMDP_STUB_GenerateSkeletonFile>
-    <NFMDP_STUB_GenerateSkeletonProject>nanoFramework_Runtime_Events</NFMDP_STUB_GenerateSkeletonProject>
+    <NFMDP_STUB_GenerateSkeletonFile>Stubs\nf_rt_events_native</NFMDP_STUB_GenerateSkeletonFile>
+    <NFMDP_STUB_GenerateSkeletonProject>NF_Rt_Events</NFMDP_STUB_GenerateSkeletonProject>
     <NFMDP_CMD_LINE_OUTPUT>false</NFMDP_CMD_LINE_OUTPUT>
     <Name>nanoFramework.Runtime.Events</Name>
   </PropertyGroup>


### PR DESCRIPTION
- add missing project property to generate stubs without using Interop features
- fixes #109
- renamed native projec files names to shortten paths
- fix typo in assemblies declaration
- fixes #96
- bump version on all Nuget packages

Signed-off-by: José Simões <jose.simoes@eclo.solutions>