### PR TITLE
Add declaration of dependencies in Nuget packages

### DIFF
--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview009</Version>
+    <Version>1.0.0-preview010</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -30,6 +30,16 @@
   <ItemGroup>
     <Folder Include="lib\" />
   </ItemGroup>
+  <ItemGroup>
+    <Dependency Include="nanoFramework.CoreLibrary">
+      <Version>1.0.0-preview022</Version>
+    </Dependency>
+  </ItemGroup>  
+  <ItemGroup>
+    <Dependency Include="nanoFramework.Runtime.Events">
+      <Version>1.0.0-preview006</Version>
+    </Dependency>
+  </ItemGroup>  
   <PropertyGroup Label="Globals">
     <ProjectGuid>96eaba11-6a33-454d-a7b2-b96ca5617e8c</ProjectGuid>
   </PropertyGroup>
@@ -39,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview009</Version>
+    <Version>1.0.0-preview010</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
+++ b/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
@@ -36,7 +36,7 @@
     <NFMDP_STUB_SKIP>false</NFMDP_STUB_SKIP>
     <NFMDP_STUB_Verbose>true</NFMDP_STUB_Verbose>
     <!-- this is one is absolutely mandatory for base class libraries -->
-    <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>    
+    <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>
     <NFMDP_STUB_VerboseMinimize>true</NFMDP_STUB_VerboseMinimize>
     <NFMDP_STUB_GenerateSkeletonFile>Stubs\win_dev_gpio_native</NFMDP_STUB_GenerateSkeletonFile>
     <NFMDP_STUB_GenerateSkeletonProject>win_dev_gpio</NFMDP_STUB_GenerateSkeletonProject>
@@ -47,7 +47,7 @@
     <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview022\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.nanoFramework.Runtime.Events.1.0.0-preview003\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.nanoFramework.Runtime.Events.1.0.0-preview006\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -81,7 +81,7 @@
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
-      <HintPath>packages\nanoFramework.nanoFramework.Runtime.Events.1.0.0-preview003\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>packages\nanoFramework.nanoFramework.Runtime.Events.1.0.0-preview006\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.Gpio/packages.config
+++ b/Windows.Devices.Gpio/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview022" />
-  <package id="nanoFramework.nanoFramework.Runtime.Events" version="1.0.0-preview003" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview007" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview005</Version>
+    <Version>1.0.0-preview006</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -27,6 +27,14 @@
       <Link>lib\Windows.Devices.Spi.xml</Link>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="lib\" />
+  </ItemGroup>  
+  <ItemGroup>
+    <Dependency Include="nanoFramework.CoreLibrary">
+      <Version>1.0.0-preview022</Version>
+    </Dependency>
+  </ItemGroup>  
   <PropertyGroup Label="Globals">
     <ProjectGuid>298761A4-D2D4-4C23-B280-89034582C925</ProjectGuid>
   </PropertyGroup>
@@ -36,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview005</Version>
+    <Version>1.0.0-preview006</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events.DELIVERABLES</Id>
-    <Version>1.0.0-preview006</Version>
+    <Version>1.0.0-preview007</Version>
     <Title>nanoFramework.Runtime.Events.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
@@ -30,6 +30,11 @@
   <ItemGroup>
     <Folder Include="lib\" />
   </ItemGroup>
+  <ItemGroup>
+    <Dependency Include="nanoFramework.CoreLibrary">
+      <Version>1.0.0-preview022</Version>
+    </Dependency>
+  </ItemGroup>  
   <PropertyGroup Label="Globals">
     <ProjectGuid>C6829C9D-C824-4609-A1E0-029594AAFFCE</ProjectGuid>
   </PropertyGroup>
@@ -39,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events</Id>
-    <Version>1.0.0-preview006</Version>
+    <Version>1.0.0-preview007</Version>
     <Title>nanoFramework.Runtime.Events</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>


### PR DESCRIPTION
- Nuget packages were missing the dependency declaration
- fixes #112
- correct reference of Runtime.Events  Nuget package in Devices.Gpio

Signed-off-by: José Simões <jose.simoes@eclo.solutions>