### PR TITLE
Fix field declaration on Devices.Spi.SpiBusInfo

### DIFF
--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview006</Version>
+    <Version>1.0.0-preview007</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -29,12 +29,12 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="lib\" />
-  </ItemGroup>  
+  </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
       <Version>1.0.0-preview022</Version>
     </Dependency>
-  </ItemGroup>  
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>298761A4-D2D4-4C23-B280-89034582C925</ProjectGuid>
   </PropertyGroup>
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview006</Version>
+    <Version>1.0.0-preview007</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/SpiBusInfo.cs
+++ b/Windows.Devices.Spi/SpiBusInfo.cs
@@ -17,13 +17,18 @@ namespace Windows.Devices.Spi
             ChipSelectLineCount = 1;
         }
 
+        private int _ChipSelectLineCount;
         /// <summary>
         /// Gets the number of chip select lines available on the bus.
         /// </summary>
         /// <value>
         /// Number of chip select lines.
         /// </value>
-        public int ChipSelectLineCount { get; }
+        public int ChipSelectLineCount
+        {
+            get { return _ChipSelectLineCount; }
+            set { _ChipSelectLineCount = value; }
+        }
 
         /// <summary>
         /// Maximum clock cycle frequency of the bus.

--- a/Windows.Devices.Spi/Windows.Devices.Spi.nfproj
+++ b/Windows.Devices.Spi/Windows.Devices.Spi.nfproj
@@ -39,7 +39,7 @@
     <NFMDP_STUB_SKIP>false</NFMDP_STUB_SKIP>
     <NFMDP_STUB_Verbose>true</NFMDP_STUB_Verbose>
     <!-- this is one is absolutely mandatory for base class libraries -->
-    <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>    
+    <NFMDP_STUB_SkeletonWithoutInterop>true</NFMDP_STUB_SkeletonWithoutInterop>
     <NFMDP_STUB_VerboseMinimize>true</NFMDP_STUB_VerboseMinimize>
     <NFMDP_STUB_GenerateSkeletonFile>Stubs\win_dev_spi_native</NFMDP_STUB_GenerateSkeletonFile>
     <NFMDP_STUB_GenerateSkeletonProject>win_dev_spi</NFMDP_STUB_GenerateSkeletonProject>


### PR DESCRIPTION
- add missing backing field
- bumped Nuget to 1.0.0-preview007

Signed-off-by: José Simões <jose.simoes@eclo.solutions>