### PR TITLE
Fix field declaration on Devices.Spi.SpiDevice

### DIFF
--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview007</Version>
+    <Version>1.0.0-preview008</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview007</Version>
+    <Version>1.0.0-preview008</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/SpiDevice.cs
+++ b/Windows.Devices.Spi/SpiDevice.cs
@@ -34,13 +34,18 @@ namespace Windows.Devices.Spi
             NativeInit(spiBus, settings.ChipSelectLine, settings.DataBitLength, (int)settings.Mode);
         }
 
+        private Spi​Connection​Settings _ConnectionSettings;
         /// <summary>
         /// Gets the connection settings for the device.
         /// </summary>
         /// <value>
         /// The connection settings.
         /// </value>
-        public Spi​Connection​Settings ConnectionSettings { get; }
+        public Spi​Connection​Settings ConnectionSettings
+        {
+            get { return _ConnectionSettings; }
+            set { _ConnectionSettings = value; }
+        }
 
         /// <summary>
         /// Gets the unique ID associated with the device.


### PR DESCRIPTION
- add missing backing field
- bumped Nuget to 1.0.0-preview008

Signed-off-by: José Simões <jose.simoes@eclo.solutions>