### PR TITLE
Update dependencies and versions

### DIFF
--- a/CoreLibrary/Nuget.CoreLibrary.DELIVERABLES/nanoFramework.CoreLibrary.DELIVERABLES.nuproj
+++ b/CoreLibrary/Nuget.CoreLibrary.DELIVERABLES/nanoFramework.CoreLibrary.DELIVERABLES.nuproj
@@ -57,7 +57,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.CoreLibrary.DELIVERABLES</Id>
-    <Version>1.0.0-preview024</Version>
+    <Version>1.0.0-preview025</Version>
     <Title>nanoFramework.CoreLibrary.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/CoreLibrary/Nuget.CoreLibrary/nanoFramework.CoreLibrary.nuproj
+++ b/CoreLibrary/Nuget.CoreLibrary/nanoFramework.CoreLibrary.nuproj
@@ -39,7 +39,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.CoreLibrary</Id>
-    <Version>1.0.0-preview024</Version>
+    <Version>1.0.0-preview025</Version>
     <Title>nanoFramework.CoreLibrary</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/CoreLibrary/System/AssemblyInfo2.cs
+++ b/CoreLibrary/System/AssemblyInfo2.cs
@@ -9,6 +9,6 @@ using System.Reflection;
 
 [assembly: CLSCompliant(true)]
 
-[assembly: AssemblyVersion("1.0.0.23")]
+[assembly: AssemblyVersion("1.0.0.0")]
 
-[assembly: AssemblyFileVersion("1.0.0.24")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview011</Version>
+    <Version>1.0.0-preview012</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -32,12 +32,12 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview023</Version>
+      <Version>1.0.0-preview025</Version>
     </Dependency>
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.Runtime.Events">
-      <Version>1.0.0-preview009</Version>
+      <Version>1.0.0-preview011</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -49,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview011</Version>
+    <Version>1.0.0-preview012</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
+++ b/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
@@ -44,10 +44,10 @@
     <Name>Windows.Devices.Gpio</Name>
   </PropertyGroup>
   <ItemGroup>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview023\lib\mscorlib.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview009\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview011\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -76,12 +76,12 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview023\lib\mscorlib.dll</HintPath>
+      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview009\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview011\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.Gpio/packages.config
+++ b/Windows.Devices.Gpio/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview023" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview009" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview025" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview011" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview012</Version>
+    <Version>1.0.0-preview013</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview022</Version>
+      <Version>1.0.0-preview025</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview012</Version>
+    <Version>1.0.0-preview013</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Windows.Devices.Spi.nfproj
+++ b/Windows.Devices.Spi/Windows.Devices.Spi.nfproj
@@ -46,7 +46,7 @@
     <NFMDP_CMD_LINE_OUTPUT>false</NFMDP_CMD_LINE_OUTPUT>
   </PropertyGroup>
   <ItemGroup>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview022\lib\mscorlib.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -68,7 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview022\lib\mscorlib.dll</HintPath>
+      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.Spi/packages.config
+++ b/Windows.Devices.Spi/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview022" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview025" />
   <package id="NuProj" version="0.11.28-beta" targetFramework="net46" developmentDependency="true" />
   <package id="NuProj.Common" version="0.11.28-beta" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events.DELIVERABLES</Id>
-    <Version>1.0.0-preview010</Version>
+    <Version>1.0.0-preview011</Version>
     <Title>nanoFramework.Runtime.Events.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview024</Version>
+      <Version>1.0.0-preview025</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events</Id>
-    <Version>1.0.0-preview010</Version>
+    <Version>1.0.0-preview011</Version>
     <Title>nanoFramework.Runtime.Events</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.10")]
-[assembly: AssemblyFileVersion("1.0.0.10")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/nanoFramework.Runtime.Events/nanoFramework.Runtime.Events.nfproj
+++ b/nanoFramework.Runtime.Events/nanoFramework.Runtime.Events.nfproj
@@ -44,7 +44,7 @@
     <Name>nanoFramework.Runtime.Events</Name>
   </PropertyGroup>
   <ItemGroup>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview024\lib\mscorlib.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview024\lib\mscorlib.dll</HintPath>
+      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/nanoFramework.Runtime.Events/packages.config
+++ b/nanoFramework.Runtime.Events/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview024"/>
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview025"/>
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>

--- a/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.DELIVERABLES/Nuget.nanoFramework.Runtime.Native.DELIVERABLES.nuproj
+++ b/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.DELIVERABLES/Nuget.nanoFramework.Runtime.Native.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Native.DELIVERABLES</Id>
-    <Version>1.0.0-preview001</Version>
+    <Version>1.0.0-preview003</Version>
     <Title>nanoFramework.Runtime.Native.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.nuproj
+++ b/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.nuproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview023</Version>
+      <Version>1.0.0-preview025</Version>
     </Dependency>
   </ItemGroup>  
   <PropertyGroup Label="Globals">
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Native</Id>
-    <Version>1.0.0-preview001</Version>
+    <Version>1.0.0-preview003</Version>
     <Title>nanoFramework.Runtime.Native</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Native/nanoFramework.Runtime.Native.nfproj
+++ b/nanoFramework.Runtime.Native/nanoFramework.Runtime.Native.nfproj
@@ -52,7 +52,7 @@
     </NFMDP_PE_ExcludeClassByName>
   </ItemGroup>
   <ItemGroup>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview023\lib\mscorlib.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -68,7 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview023\lib\mscorlib.dll</HintPath>
+      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/nanoFramework.Runtime.Native/packages.config
+++ b/nanoFramework.Runtime.Native/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview023" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview025" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- update dependencies on CorLib and Native.Events
- revert change in version for CorLib
- revert change in version for Native.Events
- bump Devices.Gpio Nuget package to v1.0.0-preview012
- bump Devices.Spi Nuget package to v1.0.0-preview013
- bump Runtine.Native Nuget package to v1.0.0-preview003
- bump CorLib Nuget package to v1.0.0-preview025
- bump Native.Events Nuget package to v1.0.0-preview011

Signed-off-by: José Simões <jose.simoes@eclo.solutions>