### PR TITLE
Work on Devices.Gpio

### DIFF
--- a/Windows.Devices.Gpio/Gpio​Controller.cs
+++ b/Windows.Devices.Gpio/Gpio​Controller.cs
@@ -13,8 +13,8 @@ namespace Windows.Devices.Gpio
     /// <remarks>To get a <see cref="Gpio​Controller"/> object, use the <see cref="GetDefault"/> method.</remarks>
     public sealed class Gpio​Controller
     {
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern bool NativeOpenpin(int pinNumber);
+        // we can have only one instance of the GpioController
+        private static GpioController s_instance = new GpioController();
 
         /// <summary>
         /// Gets the number of pins on the general-purpose I/O (GPIO) controller.
@@ -49,7 +49,7 @@ namespace Windows.Devices.Gpio
         /// <returns>The default GPIO controller for the system, or null if the system has no GPIO controller.</returns>
         public static Gpio​Controller GetDefault()
         {
-            return new Gpio​Controller();
+            return s_instance;
         }
 
         /// <summary>
@@ -123,14 +123,12 @@ namespace Windows.Devices.Gpio
         public Gpio​Pin OpenPin(int pinNumber, GpioSharingMode sharingMode)
         {
             //Note : sharingMode ignored at the moment because we do not handle shared accessed pins
-            if (NativeOpenpin(pinNumber))
-            {
-                var pin = new Gpio​Pin(pinNumber);
 
-                if (pin.Init())
-                {
-                    return pin;
-                }
+            var pin = new Gpio​Pin(pinNumber);
+
+            if (pin.Init())
+            {
+                return pin;
             }
 
             throw new System.InvalidOperationException();
@@ -148,29 +146,24 @@ namespace Windows.Devices.Gpio
         public bool TryOpenPin(int pinNumber, GpioSharingMode sharingMode, out Gpio​Pin pin, out GpioOpenStatus openStatus)
         {
             //Note : sharingMode ignored at the moment because we do not handle shared accessed pins
-            pin = null;
-            openStatus = GpioOpenStatus.PinUnavailable;
 
-            if (NativeOpenpin(pinNumber))
+            var newPin = new Gpio​Pin(pinNumber);
+
+            if (newPin.Init())
             {
-                var newPin = new Gpio​Pin(pinNumber);
+                pin = newPin;
+                openStatus = GpioOpenStatus.PinOpened;
 
-                if (newPin.Init())
-                {
-                    pin = newPin;
-                    openStatus = GpioOpenStatus.PinOpened;
-
-                    return true;
-                }
-                else
-                {
-                    // failed to init the Gpio pint
-                    pin = null;
-                    openStatus = GpioOpenStatus.PinUnavailable;
-                }
+                return true;
             }
+            else
+            {
+                // failed to init the Gpio pint
+                pin = null;
+                openStatus = GpioOpenStatus.PinUnavailable;
 
-            return false;
+                return false;
+            }
         }
     }
 }

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview017</Version>
+    <Version>1.0.0-preview018</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -49,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview017</Version>
+    <Version>1.0.0-preview018</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/EventSink.cs
+++ b/nanoFramework.Runtime.Events/EventSink.cs
@@ -173,7 +173,7 @@ namespace nanoFramework.Runtime.Events
         /// <param name="data1">Data related to the event.</param>
         /// <param name="data2">Data related to the event.</param>
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public static void PostManagerEvent(byte category, byte subCategory, ushort data1, uint data2)
+        public static void PostManagedEvent(byte category, byte subCategory, ushort data1, uint data2)
         {
             if (_eventSink != null)
             {


### PR DESCRIPTION
- remove NativeOpenpin from GpioController (the real work and checks of opening a Gpio pin are performed at the GpioPin contructor and NativeOpen so there is no point on having this here)
- add static field with default GpioController (not having this was throwing an exception)
- rework OpenPin methods
- correct typo in PostManagerEvent
- bump Nuget version to 1.0.0-preview018

Signed-off-by: José Simões <jose.simoes@eclo.solutions>