### PR TITLE
Bump Devices.Gpio to 1.0.0.22

### DIFF
--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview021</Version>
+    <Version>1.0.0-preview022</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -32,12 +32,12 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview026</Version>
+      <Version>1.0.0-preview027</Version>
     </Dependency>
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.Runtime.Events">
-      <Version>1.0.0-preview012</Version>
+      <Version>1.0.0-preview013</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -49,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview021</Version>
+    <Version>1.0.0-preview022</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.21")]
-[assembly: AssemblyFileVersion("1.0.0.21")]
+[assembly: AssemblyVersion("1.0.0.22")]
+[assembly: AssemblyFileVersion("1.0.0.22")]

--- a/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
+++ b/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
@@ -44,10 +44,10 @@
     <Name>Windows.Devices.Gpio</Name>
   </PropertyGroup>
   <ItemGroup>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview026\lib\mscorlib.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview027\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview012\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview013\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -70,13 +70,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview026\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.0.27, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview027\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview012\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.13, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview013\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.Gpio/packages.config
+++ b/Windows.Devices.Gpio/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview026" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview012" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview027" targetFramework="net46" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview013" targetFramework="net46" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- update mscorlib to 1.0.0.27
- update Runtime.Events to 1.0.0.13
- update Nuget dependencies to the above versions

Signed-off-by: José Simões <jose.simoes@eclo.solutions>