### PR TITLE
Fix bug in Runtime.Events

### DIFF
--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events.DELIVERABLES</Id>
-    <Version>1.0.0-preview013</Version>
+    <Version>1.0.0-preview014</Version>
     <Title>nanoFramework.Runtime.Events.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events</Id>
-    <Version>1.0.0-preview013</Version>
+    <Version>1.0.0-preview014</Version>
     <Title>nanoFramework.Runtime.Events</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.13")]
-[assembly: AssemblyFileVersion("1.0.0.13")]
+[assembly: AssemblyVersion("1.0.0.14")]
+[assembly: AssemblyFileVersion("1.0.0.14")]


### PR DESCRIPTION
- the static field s_eventInfoTable is not initialized in the static constructor becuase the class is created there (seems that this is the expected behaviour in nF) therefore when the GetEventInfo tries to use it it's null thus throwing the exception
- fix nanoFramework/Home#211
- rework GetEventInfo and s_eventInfoTable to use an HashTable instead of an ArrayList
- bump version to 1.0.0.14

Signed-off-by: José Simões <jose.simoes@eclo.solutions>