### PR TITLE
Work on Devices.Gpio

### DIFF
--- a/Windows.Devices.Gpio/GpioPinEventListener.cs
+++ b/Windows.Devices.Gpio/GpioPinEventListener.cs
@@ -13,7 +13,7 @@ namespace Windows.Devices.Gpio
     internal class GpioPinEventListener : IEventProcessor, IEventListener
     {
         // Map of pin numbers to GpioPin objects.
-        private IDictionary _pinMap = new Hashtable();
+        private Hashtable _pinMap = new Hashtable();
 
         public GpioPinEventListener()
         {

--- a/Windows.Devices.Gpio/Gpio​Pin.cs
+++ b/Windows.Devices.Gpio/Gpio​Pin.cs
@@ -20,17 +20,17 @@ namespace Windows.Devices.Gpio
     /// </summary>
     public sealed class Gpio​Pin : IDisposable
     {
+        private static GpioPinEventListener s_eventListener = new GpioPinEventListener();
+
         // this is used as the lock object 
         // a lock is required because multiple threads can access the GpioPin
         private object _syncLock = new object();
 
         private readonly int _pinNumber;
         private GpioPinDriveMode _driveMode = GpioPinDriveMode.Input;
-        private TimeSpan _debounceTimeout = new TimeSpan(0);
+        private TimeSpan _debounceTimeout = TimeSpan.Zero;
         private GpioPinValueChangedEventHandler _callbacks = null;
         private GpioPinValue _lastOutputValue = GpioPinValue.Low;
-
-        private static GpioPinEventListener s_eventListener = new GpioPinEventListener();
 
         internal Gpio​Pin(int pinNumber)
         {
@@ -206,6 +206,9 @@ namespace Windows.Devices.Gpio
                     // native write
                     WriteNative(value);
 
+                    // update mmemory field
+                    _lastOutputValue = value;
+
                     // trigger the pin value changed event, if any is set
                     GpioPinValueChangedEventHandler callbacks = _callbacks;
 
@@ -358,7 +361,8 @@ namespace Windows.Devices.Gpio
         private extern void NativeSetDebounceTimeout();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public extern void WriteNative(GpioPinValue value);
+        private extern void WriteNative(GpioPinValue value);
+        
         #endregion
     }
 }

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview022</Version>
+    <Version>1.0.0-preview023</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.Runtime.Events">
-      <Version>1.0.0-preview013</Version>
+      <Version>1.0.0-preview014</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -49,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview022</Version>
+    <Version>1.0.0-preview023</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.22")]
-[assembly: AssemblyFileVersion("1.0.0.22")]
+[assembly: AssemblyVersion("1.0.0.23")]
+[assembly: AssemblyFileVersion("1.0.0.23")]

--- a/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
+++ b/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
@@ -47,7 +47,7 @@
     <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview027\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview013\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview014\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -75,8 +75,8 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.13, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview013\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.14, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview014\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.Gpio/packages.config
+++ b/Windows.Devices.Gpio/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview027" targetFramework="net46" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview013" targetFramework="net46" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview014" targetFramework="net46" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- correct declaration of GpioPinEventListener._pinMap field (was using a wrong type)
- moved static field on Gpio​Pin to the top to follow guidelines
- improve declaration of _debounceTimeout with proper initilizer
- add code to update _lastOutputValue on valid write (otherwise would only all writing the first time)
- correct visibility of WriteNative to private
- update Runtime.Events to 1.0.0.14
- update Nuget dependency to the above
- bump Devices.Gpio to 1.0.0.23

Signed-off-by: José Simões <jose.simoes@eclo.solutions>