### PR TITLE
Add Nuget projects to Devices.I2c

### DIFF
--- a/Windows.Devices.I2c/Nuget.Windows.Devices.I2c.Deliverables/Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj
+++ b/Windows.Devices.I2c/Nuget.Windows.Devices.I2c.Deliverables/Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="content\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\bin\$(Configuration)\Stubs\*.*">
+      <Link>content\Stubs\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\*.txt">
+      <Link>content\txt\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\*.dump">
+      <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\*.strings">
+      <Link>content\dump\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\*.resources">
+      <Link>content\resources\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\*.il">
+      <Link>content\disasm\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4AB2EACE-321A-4272-90E6-9F58FD53675E</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath>..\packages\NuProj.0.20.4-beta\tools\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>nanoFramework.Windows.Devices.I2c.DELIVERABLES</Id>
+    <Version>1.0.0-preview001</Version>
+    <Title>nanoFramework.Windows.Devices.I2c.DELIVERABLES</Title>
+    <Authors>nanoFramework project contributors</Authors>
+    <Owners>nanoFramework project contributors</Owners>
+    <Summary>nanoFramework.Windows.Devices.I2c.DELIVERABLES is not meant for development.</Summary>
+    <Description>** DON'T REFERENCE THIS PACKAGE ** Not meant for development. This package includes the deliverable artifacts of the Windows.Devices.I2c assembly for nanoFramework. These are for testing purposes and for updating the native code base of the core library.</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>https://github.com/nanoframework/nf-class-libraries</ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright (c) 2017 The nanoFramework project contributors</Copyright>
+    <Tags>
+    </Tags>
+    <IconUrl>https://secure.gravatar.com/avatar/97d0e092247f0716db6d4b47b7d1d1ad</IconUrl>
+    <GenerateSymbolPackage>false</GenerateSymbolPackage>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/Windows.Devices.I2c/Nuget.Windows.Devices.I2c/Nuget.Windows.Devices.I2c.nuproj
+++ b/Windows.Devices.I2c/Nuget.Windows.Devices.I2c/Nuget.Windows.Devices.I2c.nuproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.I2c.dll">
+      <Link>lib\Windows.Devices.I2c.dll</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.I2c.pdb">
+      <Link>lib\Windows.Devices.I2c.pdb</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.I2c.pdbx">
+      <Link>lib\Windows.Devices.I2c.pdbx</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.I2c.pe">
+      <Link>lib\Windows.Devices.I2c.pe</Link>
+    </Content>
+    <Content Include="..\bin\$(Configuration)\Windows.Devices.I2c.xml">
+      <Link>lib\Windows.Devices.I2c.xml</Link>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="lib\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Dependency Include="nanoFramework.CoreLibrary">
+      <Version>[1.0.0-preview028]</Version>
+    </Dependency>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath>..\packages\NuProj.0.20.4-beta\tools\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>nanoFramework.Windows.Devices.I2c</Id>
+    <Version>1.0.0-preview001</Version>
+    <Title>nanoFramework.Windows.Devices.I2c</Title>
+    <Authors>nanoFramework project contributors</Authors>
+    <Owners>nanoFramework project contributors</Owners>
+    <Summary>Windows.Devices.I2c assembly for nanoFramework C# projects</Summary>
+    <Description>This package includes the Windows.Devices.I2c assembly for nanoFramework C# projects</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>https://github.com/nanoframework/nf-class-libraries</ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright (c) 2017 The nanoFramework project contributors</Copyright>
+    <Tags>nanoFramework C# csharp netmf netnf i2c micro-controller Windows.Devices.I2c</Tags>
+    <IconUrl>https://secure.gravatar.com/avatar/97d0e092247f0716db6d4b47b7d1d1ad</IconUrl>
+    <GenerateSymbolPackage>false</GenerateSymbolPackage>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/Windows.Devices.I2c/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.I2c/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyFileVersion("1.0.0.1")]

--- a/Windows.Devices.I2c/Windows.Devices.I2c.nfproj
+++ b/Windows.Devices.I2c/Windows.Devices.I2c.nfproj
@@ -1,10 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\NuProj.0.11.28-beta\build\NuProj.props" Condition="Exists('packages\NuProj.0.11.28-beta\build\NuProj.props')" />
+  <Import Project="packages\NuProj.0.20.4-beta\build\NuProj.props" Condition="Exists('packages\NuProj.0.20.4-beta\build\NuProj.props')" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
   <PropertyGroup>
@@ -46,7 +44,7 @@
     <NFMDP_CMD_LINE_OUTPUT>false</NFMDP_CMD_LINE_OUTPUT>
   </PropertyGroup>
   <ItemGroup>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview022\lib\mscorlib.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview028\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -67,8 +65,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview022\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.0.28, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview028\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
@@ -83,8 +81,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\NuProj.0.11.28-beta\build\NuProj.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\NuProj.0.11.28-beta\build\NuProj.props'))" />
-    <Error Condition="!Exists('packages\NuProj.Common.0.11.28-beta\build\dotnet\NuProj.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\NuProj.Common.0.11.28-beta\build\dotnet\NuProj.Common.targets'))" />
+    <Error Condition="!Exists('packages\NuProj.0.20.4-beta\build\NuProj.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\NuProj.0.20.4-beta\build\NuProj.props'))" />
+    <Error Condition="!Exists('packages\NuProj.Common.0.20.4-beta\build\dotnet\NuProj.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\NuProj.Common.0.20.4-beta\build\dotnet\NuProj.Common.targets'))" />
   </Target>
-  <Import Project="packages\NuProj.Common.0.11.28-beta\build\dotnet\NuProj.Common.targets" Condition="Exists('packages\NuProj.Common.0.11.28-beta\build\dotnet\NuProj.Common.targets')" />
+  <Import Project="packages\NuProj.Common.0.20.4-beta\build\dotnet\NuProj.Common.targets" Condition="Exists('packages\NuProj.Common.0.20.4-beta\build\dotnet\NuProj.Common.targets')" />
 </Project>

--- a/Windows.Devices.I2c/Windows.Devices.I2c.sln
+++ b/Windows.Devices.I2c/Windows.Devices.I2c.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Windows.Devices.I2c", "Windows.Devices.I2c.nfproj", "{D74A7890-8A23-417B-AB74-923D57E987EA}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "Nuget.Windows.Devices.I2c", "Nuget.Windows.Devices.I2c\Nuget.Windows.Devices.I2c.nuproj", "{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "Nuget.Windows.Devices.I2c.DELIVERABLES", "Nuget.Windows.Devices.I2c.Deliverables\Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj", "{4AB2EACE-321A-4272-90E6-9F58FD53675E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +19,19 @@ Global
 		{D74A7890-8A23-417B-AB74-923D57E987EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D74A7890-8A23-417B-AB74-923D57E987EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D74A7890-8A23-417B-AB74-923D57E987EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C8231C9F-4CB4-4EA4-9760-0BB50E83EEC4}
 	EndGlobalSection
 EndGlobal

--- a/Windows.Devices.I2c/nanoFramework.Windows.Devices.I2c.sln
+++ b/Windows.Devices.I2c/nanoFramework.Windows.Devices.I2c.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Windows.Devices.I2c", "Windows.Devices.I2c.nfproj", "{D74A7890-8A23-417B-AB74-923D57E987EA}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "Nuget.Windows.Devices.I2c", "Nuget.Windows.Devices.I2c\Nuget.Windows.Devices.I2c.nuproj", "{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "Nuget.Windows.Devices.I2c.DELIVERABLES", "Nuget.Windows.Devices.I2c.Deliverables\Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj", "{4AB2EACE-321A-4272-90E6-9F58FD53675E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D74A7890-8A23-417B-AB74-923D57E987EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D74A7890-8A23-417B-AB74-923D57E987EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D74A7890-8A23-417B-AB74-923D57E987EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D74A7890-8A23-417B-AB74-923D57E987EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EF0D93F-A7BC-4EF8-97D7-6FAAA91B3A13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AB2EACE-321A-4272-90E6-9F58FD53675E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C8231C9F-4CB4-4EA4-9760-0BB50E83EEC4}
+	EndGlobalSection
+EndGlobal

--- a/Windows.Devices.I2c/packages.config
+++ b/Windows.Devices.I2c/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuProj" version="0.11.28-beta" targetFramework="net46" developmentDependency="true" />
-  <package id="NuProj.Common" version="0.11.28-beta" targetFramework="net46" developmentDependency="true" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview028" targetFramework="net46" />
+  <package id="NuProj" version="0.20.4-beta" targetFramework="net46" developmentDependency="true" />
+  <package id="NuProj.Common" version="0.20.4-beta" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,11 @@ build_script:
     msbuild Windows.Devices.Spi\nanoFramework.Windows.Devices.Spi.sln /p:Configuration=Release  /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 
+    nuget restore Windows.Devices.I2c\nanoFramework.Windows.Devices.I2c.sln
+
+    msbuild Windows.Devices.I2c\nanoFramework.Windows.Devices.I2c.sln /p:Configuration=Release  /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+
     nuget restore nanoFramework.Runtime.Events\nanoFramework.Runtime.Events.sln
     
     msbuild nanoFramework.Runtime.Events\nanoFramework.Runtime.Events.sln /p:Configuration=Release  /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
- update Cor Lib to 1.0.0.28
- bump Devices.I2c to 1.0.0.1

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

