### PR TITLE
Work on Runtime.Native

### DIFF
--- a/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.DELIVERABLES/Nuget.nanoFramework.Runtime.Native.DELIVERABLES.nuproj
+++ b/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.DELIVERABLES/Nuget.nanoFramework.Runtime.Native.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Native.DELIVERABLES</Id>
-    <Version>1.0.0-preview004</Version>
+    <Version>1.0.0-preview005</Version>
     <Title>nanoFramework.Runtime.Native.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.nuproj
+++ b/nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native/Nuget.nanoFramework.Runtime.Native.nuproj
@@ -32,9 +32,9 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview026</Version>
+      <Version>[1.0.0-preview028]</Version>
     </Dependency>
-  </ItemGroup>  
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>C72CBABD-265A-4B4F-8029-F53B11F009E5</ProjectGuid>
   </PropertyGroup>
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Native</Id>
-    <Version>1.0.0-preview004</Version>
+    <Version>1.0.0-preview005</Version>
     <Title>nanoFramework.Runtime.Native</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Native/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Runtime.Native/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyFileVersion("1.0.0.5")]

--- a/nanoFramework.Runtime.Native/nanoFramework.Runtime.Native.nfproj
+++ b/nanoFramework.Runtime.Native/nanoFramework.Runtime.Native.nfproj
@@ -52,7 +52,7 @@
     </NFMDP_PE_ExcludeClassByName>
   </ItemGroup>
   <ItemGroup>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview026\lib\mscorlib.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview028\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -61,14 +61,15 @@
     <Compile Include="Debug.cs" />
     <Compile Include="Hardware\SystemInfo.cs" />
     <Compile Include="ExecutionConstraint.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="key.snk" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview026\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.0.28, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.0.0-preview028\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/nanoFramework.Runtime.Native/packages.config
+++ b/nanoFramework.Runtime.Native/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview026" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview028" targetFramework="net46" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- update CorLib to 1.0.0.28
- update Nuget dependency to above version
- change Nuget dependency to use strict version
- bump version to 1.0.0.5

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
