### PR TITLE
Update Nuspecs to enforce strict dependency versions

### DIFF
--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview025</Version>
+    <Version>1.0.0-preview026</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -32,12 +32,12 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview028</Version>
+      <Version>[1.0.0-preview028]</Version>
     </Dependency>
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.Runtime.Events">
-      <Version>1.0.0-preview014</Version>
+      <Version>[1.0.0-preview014]</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -49,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview025</Version>
+    <Version>1.0.0-preview026</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.25")]
-[assembly: AssemblyFileVersion("1.0.0.25")]
+[assembly: AssemblyVersion("1.0.0.26")]
+[assembly: AssemblyFileVersion("1.0.0.26")]

--- a/Windows.Devices.Spi/AssemblyInfo.cs
+++ b/Windows.Devices.Spi/AssemblyInfo.cs
@@ -15,5 +15,5 @@
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.0.0.16")]
-[assembly: AssemblyFileVersion("1.0.0.16")]
+[assembly: AssemblyVersion("1.0.0.17")]
+[assembly: AssemblyFileVersion("1.0.0.17")]

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview016</Version>
+    <Version>1.0.0-preview017</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview028</Version>
+      <Version>[1.0.0-preview028]</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview016</Version>
+    <Version>1.0.0-preview017</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.DELIVERABLES/Nuget.nanoFramework.Runtime.Events.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events.DELIVERABLES</Id>
-    <Version>1.0.0-preview015</Version>
+    <Version>1.0.0-preview016</Version>
     <Title>nanoFramework.Runtime.Events.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
+++ b/nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events/Nuget.nanoFramework.Runtime.Events.nuproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.CoreLibrary">
-      <Version>1.0.0-preview028</Version>
+      <Version>[1.0.0-preview028]</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Runtime.Events</Id>
-    <Version>1.0.0-preview015</Version>
+    <Version>1.0.0-preview016</Version>
     <Title>nanoFramework.Runtime.Events</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Runtime.Events/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.15")]
-[assembly: AssemblyFileVersion("1.0.0.15")]
+[assembly: AssemblyVersion("1.0.0.16")]
+[assembly: AssemblyFileVersion("1.0.0.16")]


### PR DESCRIPTION
- bump Runtime.Events to 1.0.0.16
- bump Devices.Gpio to 1.0.0.26
- bump Devices.Gpio to 1.0.0.17

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
