### PR TITLE
Update Devices.Gpio

### DIFF
--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview026</Version>
+    <Version>1.0.0-preview027</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.Runtime.Events">
-      <Version>[1.0.0-preview014]</Version>
+      <Version>[1.0.0-preview016]</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.26")]
-[assembly: AssemblyFileVersion("1.0.0.26")]
+[assembly: AssemblyVersion("1.0.0.27")]
+[assembly: AssemblyFileVersion("1.0.0.27")]

--- a/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
+++ b/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
@@ -47,7 +47,7 @@
     <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview028\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview015\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview016\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -75,8 +75,8 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.15, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview015\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.16, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview016\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.Gpio/packages.config
+++ b/Windows.Devices.Gpio/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview028" targetFramework="net46" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview015" targetFramework="net46" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview016" targetFramework="net46" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- update ref to Runtime.Events to 1.0.0.16
- update Nuget dependency to the above
- bump Devices.Gpio to 1.0.0.27

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

