### PR TITLE
Remove workaround

### DIFF
--- a/CoreLibrary/System/Number.cs
+++ b/CoreLibrary/System/Number.cs
@@ -287,8 +287,6 @@ namespace System
             ValidateFormat(format, out formatCh, out precision);
 
             String result = FormatNative(value, formatCh, precision);
-            // TODO: fix the FormatNative() method then remove the following line. See https://github.com/nanoframework/nf-interpreter/issues/285
-            if (result.Length == 0) return string.Empty;
 
             if (isInteger)
             {

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -49,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview026</Version>
+    <Version>1.0.0-preview027</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>


### PR DESCRIPTION
## Description
Remove temporary fix added in nanoframework/nf-class-libraries#3.

## How Has This Been Tested? (if applicable)
C# test app with a call to `Int32.ToString()` and `Int32.ToString("N0")` without throwing any exception.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
