### PR TITLE
Work on Devices.Spi

### DIFF
--- a/Windows.Devices.Spi/AssemblyInfo.cs
+++ b/Windows.Devices.Spi/AssemblyInfo.cs
@@ -15,5 +15,5 @@
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.0.0.17")]
-[assembly: AssemblyFileVersion("1.0.0.17")]
+[assembly: AssemblyVersion("1.0.0.18")]
+[assembly: AssemblyFileVersion("1.0.0.18")]

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview017</Version>
+    <Version>1.0.0-preview018</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview017</Version>
+    <Version>1.0.0-preview018</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/SpiController.cs
+++ b/Windows.Devices.Spi/SpiController.cs
@@ -12,7 +12,10 @@ namespace Windows.Devices.Spi
     /// </summary>
     public sealed class SpiController
     {
-        internal static ArrayList DeviceCollection = new ArrayList();
+        // we can have only one instance of the SpiController
+        private static SpiController s_instance = new SpiController();
+
+        internal static Hashtable s_deviceCollection = new Hashtable();
 
         /// <summary>
         /// Gets the default SPI controller on the system.
@@ -20,7 +23,7 @@ namespace Windows.Devices.Spi
         /// <returns>The default SPI controller on the system, or null if the system has no SPI controller.</returns>
         public static SpiController GetDefault()
         {
-            return new SpiController();
+            return s_instance;
         }
 
         /// <summary>

--- a/Windows.Devices.Spi/SpiDevice.cs
+++ b/Windows.Devices.Spi/SpiDevice.cs
@@ -39,7 +39,7 @@ namespace Windows.Devices.Spi
             var deviceId = (spiBus[3] - 48) * 1000 + settings.ChipSelectLine;
 
             // check if this device ID already exists
-            if (!SpiController.DeviceCollection.Contains(deviceId))
+            if (!SpiController.s_deviceCollection.Contains(deviceId))
             {
                 _spiBus = spiBus;
                 _connectionSettings = new SpiConnectionSettings(settings);
@@ -50,7 +50,7 @@ namespace Windows.Devices.Spi
                 NativeInit();
 
                 // add to device collection
-                SpiController.DeviceCollection.Add(deviceId);
+                SpiController.s_deviceCollection.Add(deviceId, this);
             }
             else
             {
@@ -229,7 +229,7 @@ namespace Windows.Devices.Spi
             if (!_disposedValue)
             {
                 // remove from device collection
-                SpiController.DeviceCollection.Remove(_deviceId);
+                SpiController.s_deviceCollection.Remove(_deviceId);
 
                 if (disposing)
                 {
@@ -247,7 +247,7 @@ namespace Windows.Devices.Spi
         private extern void DisposeNative();
 
         /// <summary>
-        /// Finalizes the instance of the <see cref="Gpio​Pin"/> class.
+        /// Finalizes the instance of the <see cref="SpiDevice"/> class.
         /// </summary>
         ~SpiDevice()
         {


### PR DESCRIPTION
## Description
- replace DeviceCollection type to HashTable (allows storing the SpiDevice)
- rename DeviceCollection to follow guideline
- rework GetDefault() to return singleton instance instead of always creating a new SpiController object
- correct comment on SpiDevice.DisposeNative
- bump Devices.Spi to 1.0.0.18

## Motivation and Context
- Fixes issue with finding duplicate devices

## How Has This Been Tested? (if applicable)
- requires testing 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>