### PR TITLE
Work on Devices.I2c

### DIFF
--- a/Windows.Devices.I2c/I2cController.cs
+++ b/Windows.Devices.I2c/I2cController.cs
@@ -13,7 +13,10 @@ namespace Windows.Devices.I2c
     /// </summary>
 	public sealed class I2cController
     {
-        internal static ArrayList DeviceCollection = new ArrayList();
+        // we can have only one instance of the SpiController
+        private static I2cController s_instance = new I2cController();
+
+        internal static Hashtable s_deviceCollection = new Hashtable();
 
         /// <summary>
         /// Gets the default I2C controller on the system.
@@ -21,7 +24,7 @@ namespace Windows.Devices.I2c
         /// <returns>The default I2C controller on the system, or null if the system has no I2C controller.</returns>
         public static I2cController GetDefault()
         {
-            return new I2cController();
+            return s_instance;
         }
 
         /// <summary>

--- a/Windows.Devices.I2c/I2cDevice.cs
+++ b/Windows.Devices.I2c/I2cDevice.cs
@@ -39,7 +39,7 @@ namespace Windows.Devices.I2c
             var deviceId = (i2cBus[3] - 48) * 1000 + settings.SlaveAddress;
 
             // check if this device ID already exists
-            //if (!I2cController.DeviceCollection.Contains(deviceId))
+            if (!I2cController.s_deviceCollection.Contains(deviceId))
             {
                 _i2cBus = i2cBus;
                 _connectionSettings = new I2cConnectionSettings(settings.SlaveAddress)
@@ -54,7 +54,7 @@ namespace Windows.Devices.I2c
                 NativeInit();
 
                 // add to device collection
-                I2cController.DeviceCollection.Add(deviceId);
+                I2cController.s_deviceCollection.Add(deviceId, this);
             }
             /*
             else
@@ -236,7 +236,7 @@ namespace Windows.Devices.I2c
             if (!_disposedValue)
             {
                 // remove from device collection
-                I2cController.DeviceCollection.Remove(_deviceId);
+                I2cController.s_deviceCollection.Remove(_deviceId);
 
                 if (disposing)
                 {

--- a/Windows.Devices.I2c/Nuget.Windows.Devices.I2c.Deliverables/Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj
+++ b/Windows.Devices.I2c/Nuget.Windows.Devices.I2c.Deliverables/Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.I2c.DELIVERABLES</Id>
-    <Version>1.0.0-preview001</Version>
+    <Version>1.0.0-preview002</Version>
     <Title>nanoFramework.Windows.Devices.I2c.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.I2c/Nuget.Windows.Devices.I2c/Nuget.Windows.Devices.I2c.nuproj
+++ b/Windows.Devices.I2c/Nuget.Windows.Devices.I2c/Nuget.Windows.Devices.I2c.nuproj
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.I2c</Id>
-    <Version>1.0.0-preview001</Version>
+    <Version>1.0.0-preview002</Version>
     <Title>nanoFramework.Windows.Devices.I2c</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.I2c/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.I2c/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.1")]
-[assembly: AssemblyFileVersion("1.0.0.1")]
+[assembly: AssemblyVersion("1.0.0.2")]
+[assembly: AssemblyFileVersion("1.0.0.2")]


### PR DESCRIPTION
## Description
- replace DeviceCollection type to HashTable (allows storing the I2cDevice)
- rename DeviceCollection to follow guideline
- rework GetDefault() to return singleton instance instead of always creating a new I2cController object
- correct comment on I2cDevice.DisposeNative
- bump Devices.I2c to 1.0.0.2

## Motivation and Context
- Fixes issue with finding duplicate devices

## How Has This Been Tested? (if applicable)
- requires testing 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>