### PR TITLE
Bump several class libs

### DIFF
--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.DELIVERABLES/Nuget.Windows.Devices.Gpio.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Id>
-    <Version>1.0.0-preview027</Version>
+    <Version>1.0.0-preview028</Version>
     <Title>nanoFramework.Windows.Devices.Gpio.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
+++ b/Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio/Nuget.Windows.Devices.Gpio.nuproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Dependency Include="nanoFramework.Runtime.Events">
-      <Version>[1.0.0-preview016]</Version>
+      <Version>[1.0.0-preview017]</Version>
     </Dependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -49,7 +49,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Gpio</Id>
-    <Version>1.0.0-preview027</Version>
+    <Version>1.0.0-preview028</Version>
     <Title>nanoFramework.Windows.Devices.Gpio</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.27")]
-[assembly: AssemblyFileVersion("1.0.0.27")]
+[assembly: AssemblyVersion("1.0.0.28")]
+[assembly: AssemblyFileVersion("1.0.0.28")]

--- a/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
+++ b/Windows.Devices.Gpio/Windows.Devices.Gpio.nfproj
@@ -47,7 +47,7 @@
     <NFMDP_PE_LoadHints Include="packages\nanoFramework.CoreLibrary.1.0.0-preview028\lib\mscorlib.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview016\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="packages\nanoFramework.Runtime.Events.1.0.0-preview017\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -75,8 +75,8 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.16, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview016\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.17, Culture=neutral, PublicKeyToken=72027bbd7f714be2">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.0.0-preview017\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Windows.Devices.Gpio/packages.config
+++ b/Windows.Devices.Gpio/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview028" targetFramework="net46" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview016" targetFramework="net46" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.0-preview017" targetFramework="net46" />
   <package id="NuProj" version="0.20.4-beta" developmentDependency="true" />
   <package id="NuProj.Common" version="0.20.4-beta" developmentDependency="true" />
 </packages>

--- a/Windows.Devices.I2c/Nuget.Windows.Devices.I2c.Deliverables/Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj
+++ b/Windows.Devices.I2c/Nuget.Windows.Devices.I2c.Deliverables/Nuget.Windows.Devices.I2c.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.I2c.DELIVERABLES</Id>
-    <Version>1.0.0-preview002</Version>
+    <Version>1.0.0-preview003</Version>
     <Title>nanoFramework.Windows.Devices.I2c.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.I2c/Nuget.Windows.Devices.I2c/Nuget.Windows.Devices.I2c.nuproj
+++ b/Windows.Devices.I2c/Nuget.Windows.Devices.I2c/Nuget.Windows.Devices.I2c.nuproj
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.I2c</Id>
-    <Version>1.0.0-preview002</Version>
+    <Version>1.0.0-preview003</Version>
     <Title>nanoFramework.Windows.Devices.I2c</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.I2c/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.I2c/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.2")]
-[assembly: AssemblyFileVersion("1.0.0.2")]
+[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyFileVersion("1.0.0.3")]

--- a/Windows.Devices.Spi/AssemblyInfo.cs
+++ b/Windows.Devices.Spi/AssemblyInfo.cs
@@ -15,5 +15,5 @@
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.0.0.18")]
-[assembly: AssemblyFileVersion("1.0.0.18")]
+[assembly: AssemblyVersion("1.0.0.19")]
+[assembly: AssemblyFileVersion("1.0.0.19")]

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi.DELIVERABLES/Nuget.Windows.Devices.Spi.DELIVERABLES.nuproj
@@ -42,7 +42,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Id>
-    <Version>1.0.0-preview018</Version>
+    <Version>1.0.0-preview019</Version>
     <Title>nanoFramework.Windows.Devices.Spi.DELIVERABLES</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
+++ b/Windows.Devices.Spi/Nuget.Windows.Devices.Spi/Nuget.Windows.Devices.Spi.nuproj
@@ -44,7 +44,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Windows.Devices.Spi</Id>
-    <Version>1.0.0-preview018</Version>
+    <Version>1.0.0-preview019</Version>
     <Title>nanoFramework.Windows.Devices.Spi</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>


### PR DESCRIPTION
- Windows.Devices.Gpio to 1.0.0.28
- Windows.Devices.Spi to 1.0.0.19
- Windows.Devices.I2c to 1.0.0.3

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

